### PR TITLE
Add support for the Launchpad Mini (MK1)

### DIFF
--- a/src/launchpad_mini/input.rs
+++ b/src/launchpad_mini/input.rs
@@ -7,6 +7,8 @@ pub enum Message {
     Press { button: Button },
     /// A button was released
     Release { button: Button },
+    /// Emitted after a text scroll ends or loops
+    TextEndedOrLooped,
 }
 
 fn decode_grid_button(btn: u8) -> Button {
@@ -49,6 +51,7 @@ impl crate::InputDevice for Input {
                     other => panic!("Unexpected control note-on velocity {}", other),
                 }
             }
+            &[0xB0, 0, 3] => Message::TextEndedOrLooped,
             // YES we have no note off message handler here because it's not used by the launchpad.
             // It sends zero-velocity note-on messages instead.
             other => panic!("Unexpected midi message: {:?}", other),

--- a/src/launchpad_mini/mod.rs
+++ b/src/launchpad_mini/mod.rs
@@ -106,6 +106,7 @@ impl crate::DeviceSpec for Spec {
                 x: button.abs_x() as u32,
                 y: button.abs_y() as u32,
             }),
+            Message::TextEndedOrLooped => None,
         }
     }
 }

--- a/src/launchpad_mini/output.rs
+++ b/src/launchpad_mini/output.rs
@@ -198,17 +198,19 @@ impl Output {
         self.turn_on_all_leds(Brightness::Off)
     }
 
-    pub fn light(&mut self, button: Button, color: Color) -> Result<(), crate::MidiError> {
-        self.set_button(button, color, DoubleBufferingBehavior::Copy)
-    }
-
-    pub fn light_all_rapid(&mut self, color: Color) -> Result<(), crate::MidiError> {
-        let dbb = DoubleBufferingBehavior::None;
-
+    pub fn set_all_buttons(&mut self, color: Color, dbb: DoubleBufferingBehavior) -> Result<(), crate::MidiError> {
         for _ in 0..40 {
             self.set_button_rapid(color, dbb, color, dbb)?;
         }
 
         Ok(())
+    }
+
+    pub fn light(&mut self, button: Button, color: Color) -> Result<(), crate::MidiError> {
+        self.set_button(button, color, DoubleBufferingBehavior::Copy)
+    }
+
+    pub fn light_all(&mut self, color: Color) -> Result<(), crate::MidiError> {
+        self.set_all_buttons(color, DoubleBufferingBehavior::Copy)
     }
 }

--- a/src/launchpad_mini/output.rs
+++ b/src/launchpad_mini/output.rs
@@ -167,6 +167,19 @@ impl Output {
         self.send(&[0xB0, 0, last_byte])
     }
 
+    pub fn scroll_text(
+        &mut self,
+        text: &[u8],
+        color: Color,
+        should_loop: bool,
+    ) -> Result<(), crate::MidiError> {
+        let color_code = make_color_code_loopable(color, should_loop);
+
+        let bytes = &[&[240, 0, 32, 41, 9, color_code], text, &[247]].concat();
+
+        return self.send(bytes);
+    }
+
     fn change_grid_mapping_mode(&mut self, mode: GridMappingMode) -> Result<(), crate::MidiError> {
         let mode = match mode {
             GridMappingMode::Session => 0,

--- a/src/launchpad_s/output.rs
+++ b/src/launchpad_s/output.rs
@@ -190,17 +190,19 @@ impl Output {
         self.turn_on_all_leds(Brightness::Off)
     }
 
-    pub fn light(&mut self, button: Button, color: Color) -> Result<(), crate::MidiError> {
-        self.set_button(button, color, DoubleBufferingBehavior::Copy)
-    }
-
-    pub fn light_all_rapid(&mut self, color: Color) -> Result<(), crate::MidiError> {
-        let dbb = DoubleBufferingBehavior::None;
-
+    pub fn set_all_buttons(&mut self, color: Color, dbb: DoubleBufferingBehavior) -> Result<(), crate::MidiError> {
         for _ in 0..40 {
             self.set_button_rapid(color, dbb, color, dbb)?;
         }
 
         Ok(())
+    }
+
+    pub fn light(&mut self, button: Button, color: Color) -> Result<(), crate::MidiError> {
+        self.set_button(button, color, DoubleBufferingBehavior::Copy)
+    }
+
+    pub fn light_all_rapid(&mut self, color: Color) -> Result<(), crate::MidiError> {
+        self.set_all_buttons(color, DoubleBufferingBehavior::Copy)
     }
 }

--- a/src/launchpad_s/output.rs
+++ b/src/launchpad_s/output.rs
@@ -204,12 +204,3 @@ impl Output {
         Ok(())
     }
 }
-
-fn make_color_code_loopable(color: Color, should_loop: bool) -> u8 {
-    // Bit 6 - Loop - If 1: loop the text
-    // Bit 5..4 - Green LED brightness
-    // Bit 3..2 - uhhhh, I think these should probably be empty?
-    // Bit 1..0 - Red LED brightness
-
-    ((should_loop as u8) << 6) | (color.green() << 4) | color.red()
-}

--- a/src/protocols/double_buffering.rs
+++ b/src/protocols/double_buffering.rs
@@ -89,3 +89,12 @@ pub(crate) fn make_color_code(color: Color, dbb: DoubleBufferingBehavior) -> u8 
     };
     (color.green << 4) | (double_buffering_code << 2) | color.red
 }
+
+pub(crate) fn make_color_code_loopable(color: Color, should_loop: bool) -> u8 {
+    // Bit 6 - Loop - If 1: loop the text
+    // Bit 5..4 - Green LED brightness
+    // Bit 3..2 - uhhhh, I think these should probably be empty?
+    // Bit 1..0 - Red LED brightness
+
+    ((should_loop as u8) << 6) | (color.green() << 4) | color.red()
+}

--- a/src/protocols/double_buffering.rs
+++ b/src/protocols/double_buffering.rs
@@ -93,7 +93,7 @@ pub(crate) fn make_color_code(color: Color, dbb: DoubleBufferingBehavior) -> u8 
 pub(crate) fn make_color_code_loopable(color: Color, should_loop: bool) -> u8 {
     // Bit 6 - Loop - If 1: loop the text
     // Bit 5..4 - Green LED brightness
-    // Bit 3..2 - uhhhh, I think these should probably be empty?
+    // Bit 3..2 - Clear/Copy (as seen in make_color_code), which don't apply for text
     // Bit 1..0 - Red LED brightness
 
     ((should_loop as u8) << 6) | (color.green() << 4) | color.red()


### PR DESCRIPTION
This adds support for the Launchpad Mini.

The device seems to be very similar to the Launchpad S and as such most of the code was copied from that implementation (and checked against the programmer docs), but missing a number of features, such as text scrolling.

There are a few things worth noting:

* I changed `light_all_rapid` to also take the `DoubleBufferingBehavior` as an argument. I personally think this is better than assuming `DoubleBufferingBehaviod::None`, as the Launchpad S implementation does - it may be worth changing that.
* The implementation of `mini::Spec::flush` (when copied from the Launchpad S) was incomplete, as it only set the main body LEDs. I updated it to send *all* the LEDs, which seems to be in line with the math (any time > 40 LEDs are updated, use rapid mode which lines up with all 80 LEDs divided by 2).
* Because the Mini, the Standard LP, and the LP S seem to share almost all the same implementation, it may be worth making this code generic or at least introducing a trait so it doesn't need to be copied between all the separate implementations. This would also make it so a subset of features on all 9x9 2-LED-color devices could pretty much be used interchangeably.