### PR TITLE
Update color names to match the Launchpad S guide

### DIFF
--- a/src/protocols/double_buffering.rs
+++ b/src/protocols/double_buffering.rs
@@ -6,10 +6,20 @@ pub struct Color {
 }
 
 impl Color {
-    pub const BLACK: Color = Color { red: 0, green: 0 };
+    // Standard colors
+    pub const OFF: Color = Color { red: 0, green: 0 };
     pub const RED: Color = Color { red: 3, green: 0 };
     pub const GREEN: Color = Color { red: 0, green: 3 };
-    pub const YELLOW: Color = Color { red: 3, green: 3 };
+    pub const AMBER: Color = Color { red: 3, green: 3 };
+
+    // Extended colors
+    pub const DIM_GREEN: Color = Color { red: 0, green: 1 };
+    pub const DIM_RED: Color = Color { red: 1, green: 0 };
+    pub const ORANGE: Color = Color { red: 3, green: 2 };
+    pub const YELLOW: Color = Color { red: 2, green: 3 };
+
+    // Alias colors
+    pub const BLACK: Color = Color::OFF;
 
     /// Create a new color from the given red and green components.
     ///


### PR DESCRIPTION
Pretty much all the documentation I've found refer to the full-on green/red color as amber, so I made that change. The "extended colors" are from the Launchpad S [programmer's manual](https://www.bhphotovideo.com/lit_files/88417.pdf), though I'm not sure they should be included as yellow on the LP mini seems to be green 3, red 1 (as opposed to green 3, red 2 in the manual) and orange seems to be red 3, green 1.

