### PR TITLE
Add device and version inquiry for Launchpad Mini and Launchpad S

### DIFF
--- a/src/launchpad_mini/input.rs
+++ b/src/launchpad_mini/input.rs
@@ -1,3 +1,5 @@
+use crate::protocols::query::*;
+
 use super::Button;
 
 /// A Launchpad Mini input message
@@ -7,6 +9,10 @@ pub enum Message {
     Press { button: Button },
     /// A button was released
     Release { button: Button },
+    /// The response to a [device inquiry request](super::Output::request_device_inquiry)
+    DeviceInquiry(DeviceInquiry),
+    /// The response to a [version inquiry request](super::Output::request_version_inquiry)
+    VersionInquiry(VersionInquiry),
 }
 
 fn decode_grid_button(btn: u8) -> Button {
@@ -25,6 +31,14 @@ impl crate::InputDevice for Input {
     type Message = Message;
 
     fn decode_message(_timestamp: u64, data: &[u8]) -> Message {
+        if let Some(device_inquiry) = parse_device_query(data) {
+            return Message::DeviceInquiry(device_inquiry);
+        }
+
+        if let Some(version_inquiry) = parse_version_query(data) {
+            return Message::VersionInquiry(version_inquiry);
+        }
+
         // first byte of a launchpad midi message is the message type
         match data {
             // Note on

--- a/src/launchpad_mini/mod.rs
+++ b/src/launchpad_mini/mod.rs
@@ -106,6 +106,8 @@ impl crate::DeviceSpec for Spec {
                 x: button.abs_x() as u32,
                 y: button.abs_y() as u32,
             }),
+            Message::DeviceInquiry(_) => None,
+            Message::VersionInquiry(_) => None,
         }
     }
 }

--- a/src/launchpad_mini/output.rs
+++ b/src/launchpad_mini/output.rs
@@ -4,6 +4,7 @@ use super::Button;
 use crate::OutputDevice;
 
 pub use crate::protocols::double_buffering::*;
+pub use crate::protocols::query::*;
 
 #[allow(dead_code)] // to prevent "variant is never constructed" warning
 enum GridMappingMode {
@@ -165,6 +166,14 @@ impl Output {
             | d.displayed_buffer as u8;
 
         self.send(&[0xB0, 0, last_byte])
+    }
+
+    pub fn request_device_inquiry(&mut self, query: DeviceIdQuery) -> Result<(), crate::MidiError> {
+        request_device_inquiry(self, query)
+    }
+
+    pub fn request_version_inquiry(&mut self) -> Result<(), crate::MidiError> {
+        request_version_inquiry(self)
     }
 
     fn change_grid_mapping_mode(&mut self, mode: GridMappingMode) -> Result<(), crate::MidiError> {

--- a/src/launchpad_mk2/output.rs
+++ b/src/launchpad_mk2/output.rs
@@ -1,5 +1,7 @@
 use midir::MidiOutputConnection;
 
+pub use crate::protocols::query::*;
+
 use super::Button;
 use crate::OutputDevice;
 
@@ -124,14 +126,6 @@ pub enum LightMode {
     Flash,
     /// A smooth pulse
     Pulse,
-}
-
-/// Used for the Device Inquiry message
-pub enum DeviceIdQuery {
-    /// Send the Device Inquiry request to a specific device id
-    Specific(u8),
-    /// Send the Device Inquiry request to all devices
-    Any,
 }
 
 /// Volume faders light from the bottom up, and pan faders light from the centre out.
@@ -581,17 +575,7 @@ impl Output {
     /// In order to be able to receive the Launchpad Mk2's response to this request,
     /// you must have a Launchpad Mk2 input object set up.
     pub fn request_device_inquiry(&mut self, query: DeviceIdQuery) -> Result<(), crate::MidiError> {
-        const QUERY_DEVICE_ID_FOR_ANY: u8 = 127;
-
-        let query_device_id = match query {
-            DeviceIdQuery::Specific(device_id) => {
-                assert_ne!(device_id, QUERY_DEVICE_ID_FOR_ANY);
-                device_id
-            }
-            DeviceIdQuery::Any => QUERY_DEVICE_ID_FOR_ANY,
-        };
-
-        self.send(&[240, 126, query_device_id, 6, 1, 247])
+        request_device_inquiry(self, query)
     }
 
     /// Requests the Launchpad Mk2 to send a so-called version inquiry. The version inquiry contains
@@ -601,7 +585,7 @@ impl Output {
     /// In order to be able to receive the Launchpad Mk2's response to this request,
     /// you must have a Launchpad Mk2 input object set up.
     pub fn request_version_inquiry(&mut self) -> Result<(), crate::MidiError> {
-        self.send(&[240, 0, 32, 41, 0, 112, 247])
+        request_version_inquiry(self)
     }
 
     /// Starts a text scroll across the screen. The screen is temporarily cleared. You can specify

--- a/src/launchpad_s/output.rs
+++ b/src/launchpad_s/output.rs
@@ -4,6 +4,7 @@ use super::Button;
 use crate::OutputDevice;
 
 pub use crate::protocols::double_buffering::*;
+pub use crate::protocols::query::*;
 
 /**
 The Launchpad S output connection handler.
@@ -161,11 +162,13 @@ impl Output {
         self.send(&[0xB0, 0, last_byte])
     }
 
-    // TODO: fix this
-    // Uncommented because I have no idea to parse the return format
-    // pub fn request_device_inquiry(&mut self) -> Result<(), crate::MidiError> {
-    //     self.send(&[240, 126, 127, 6, 1, 247])
-    // }
+    pub fn request_device_inquiry(&mut self, query: DeviceIdQuery) -> Result<(), crate::MidiError> {
+        request_device_inquiry(self, query)
+    }
+
+    pub fn request_version_inquiry(&mut self) -> Result<(), crate::MidiError> {
+        request_version_inquiry(self)
+    }
 
     pub fn scroll_text(
         &mut self,

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod double_buffering;
+pub(crate) mod query;
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 /// The button type used for Launchpads with 80 buttons

--- a/src/protocols/query.rs
+++ b/src/protocols/query.rs
@@ -1,0 +1,95 @@
+/// Used for the Device Inquiry message
+pub enum DeviceIdQuery {
+    /// Send the Device Inquiry request to a specific device id
+    Specific(u8),
+    /// Send the Device Inquiry request to all devices
+    Any,
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+pub struct DeviceInquiry {
+    pub device_id: u8,
+    pub family_code: u16,
+    pub family_member_code: u16,
+    pub firmware_revision: u32,
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+pub struct VersionInquiry {
+    pub bootloader_version: u32,
+    pub firmware_version: u32,
+    pub bootloader_size: u16,
+}
+
+pub(crate) fn request_device_inquiry<T>(
+    output: &mut T,
+    query: DeviceIdQuery,
+) -> Result<(), crate::MidiError>
+where
+    T: crate::OutputDevice,
+{
+    const QUERY_DEVICE_ID_FOR_ANY: u8 = 127;
+
+    let query_device_id = match query {
+        DeviceIdQuery::Specific(device_id) => {
+            assert_ne!(device_id, QUERY_DEVICE_ID_FOR_ANY);
+            device_id
+        }
+        DeviceIdQuery::Any => QUERY_DEVICE_ID_FOR_ANY,
+    };
+
+    output.send(&[240, 126, query_device_id, 6, 1, 247])
+}
+
+pub(crate) fn request_version_inquiry<T>(output: &mut T) -> Result<(), crate::MidiError>
+where
+    T: crate::OutputDevice,
+{
+    output.send(&[240, 0, 32, 41, 0, 112, 247])
+}
+
+pub(crate) fn parse_device_query(data: &[u8]) -> Option<DeviceInquiry> {
+    if let &[240, 126, device_id, 6, 2, 0, 32, 41, fc1, fc2, fmc1, fmc2, fr1, fr2, fr3, fr4, 247] =
+        data
+    {
+        let family_code = u16::from_be_bytes([fc1, fc2]);
+        let family_member_code = u16::from_be_bytes([fmc1, fmc2]);
+
+        let firmware_revision = fr1 as u32 * 1000 + fr2 as u32 * 100 + fr3 as u32 * 10 + fr4 as u32;
+
+        Some(DeviceInquiry {
+            device_id,
+            family_code,
+            family_member_code,
+            firmware_revision,
+        })
+    } else {
+        None
+    }
+}
+
+pub(crate) fn parse_version_query(data: &[u8]) -> Option<VersionInquiry> {
+    if let &[240, 0, 32, 41, 0, 112, bl1, bl2, bl3, bl4, bl5, fw1, fw2, fw3, fw4, fw5, bs1, bs2, 247] = data {
+        let bootloader_version = bl1 as u32 * 10000
+            + bl2 as u32 * 1000
+            + bl3 as u32 * 100
+            + bl4 as u32 * 10
+            + bl5 as u32;
+
+        let firmware_version = fw1 as u32 * 10000
+            + fw2 as u32 * 1000
+            + fw3 as u32 * 100
+            + fw4 as u32 * 10
+            + fw5 as u32;
+
+        let bootloader_size = u16::from_be_bytes([bs1, bs2]);
+
+        Some(VersionInquiry {
+            bootloader_version,
+            firmware_version,
+            bootloader_size,
+        })
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
This moves the device/version inquiry code from the Launchpad MK2 into a shared location, fixes it up, and uses it for the 3 devices which should support it. The Launchpad Control may also support it, but I don't have one to test with. This does unfortunately mean pattern matching and destructuring these is a little more annoying (because of the shared types) but it does let us share a pretty big chunk of code.

While I was in the area, I also cleaned up the matching code for the MK2.