### PR TITLE
Upgrade midir to 0.9.1 (0.7.0 no longer compiles)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ keywords = ["novation", "launchpad", "midi", "midi-controller", "lightshow"]
 categories = ["api-bindings", "games", "graphics", "rendering", "multimedia::images"]
 
 [dependencies]
-midir = "0.7"
+midir = "0.9.1"
 embedded-graphics = { version = "0.7", optional = true }


### PR DESCRIPTION
Trying to compile midir 0.7.0 (and so launchy) outputs:
```
error[E0793]: reference to packed field is unaligned
   --> C:\Users\maximxls\.cargo\registry\src\github.com-1ecc6299db9ec823\midir-0.7.0\src\backend\winmm\mod.rs:100:38
    |
100 |         let pname: &[u16] = unsafe { &device_caps.szPname }; // requires unsafe because of packed alignment ...
    |                                      ^^^^^^^^^^^^^^^^^^^^
    |
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)

error[E0793]: reference to packed field is unaligned
   --> C:\Users\maximxls\.cargo\registry\src\github.com-1ecc6299db9ec823\midir-0.7.0\src\backend\winmm\mod.rs:356:38
    |
356 |         let pname: &[u16] = unsafe { &device_caps.szPname }; // requires unsafe because of packed alignment ...
    |                                      ^^^^^^^^^^^^^^^^^^^^
    |
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
```

So midir needs to be upgraded