### PR TITLE
feat: add support for LaunchPad Mini MK3

### DIFF
--- a/examples/validate-mini-mk3/main.rs
+++ b/examples/validate-mini-mk3/main.rs
@@ -1,0 +1,262 @@
+//! Validation suite for the Mini MK3 direct API
+//!
+//! This exercises all supported features.
+use std::io::{stdin, stdout, Write};
+
+use launchy::{
+    mini_mk3::{Button, Message, PaletteColor, RgbColor, SleepMode},
+    s::DeviceIdQuery,
+    Canvas, Color, InputDevice, MidiError, MsgPollingWrapper, OutputDevice, Pad,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Show all interface names.
+    let midi = midir::MidiOutput::new("launchy")?;
+    for port in midi.ports() {
+        println!("{}", midi.port_name(&port)?);
+    }
+
+    // Load MK3
+    let mut mk3 = launchy::mini_mk3::Output::guess()?;
+    mk3.stop_scroll()?;
+
+    let mut failed_tests: Vec<String> = vec![];
+
+    macro_rules! test {
+        ($description:literal, $test:block) => {
+            print!("{} [Y/n] ", $description);
+            stdout().flush()?;
+            $test;
+            if !yes_no()? {
+                failed_tests.push($description.into());
+            }
+        };
+    }
+
+    println!("/////////////////////////////////////////////");
+    println!("//  OUTPUT TESTS");
+    println!("/////////////////////////////////////////////");
+
+    test!("All lights turn dark grey", {
+        mk3.light_all(PaletteColor::DARK_GRAY)?;
+    });
+
+    mk3.light_all(PaletteColor::BLACK)?;
+
+    test!("Control button 0 turns palette red", {
+        mk3.light(Button::ControlButton { index: 0 }, PaletteColor::RED)?;
+    });
+    test!("Control button 1 turns an RGB color purple", {
+        mk3.light_rgb(
+            Button::ControlButton { index: 1 },
+            RgbColor::new(127, 0, 127),
+        )?;
+    });
+    test!("Grid button (0, 0) turns palette red", {
+        mk3.light(Button::GridButton { x: 0, y: 0 }, PaletteColor::new(5))?;
+    });
+    test!("Grid button (1, 0) turns RGB purple", {
+        mk3.light_rgb(
+            Button::GridButton { x: 1, y: 0 },
+            RgbColor::new(127, 0, 127),
+        )?;
+    });
+    test!("Grid buttons (0, 1) and (1, 1) turn palette yellow", {
+        mk3.light_multiple([
+            (Button::GridButton { x: 0, y: 1 }, PaletteColor::YELLOW),
+            (Button::GridButton { x: 1, y: 1 }, PaletteColor::YELLOW),
+        ])?;
+    });
+    test!(
+        "Grid buttons (0, 2) and (1, 2) turn palette white and light purple",
+        {
+            mk3.light_multiple_rgb([
+                (
+                    Button::GridButton { x: 0, y: 2 },
+                    RgbColor::new(127, 127, 127),
+                ),
+                (
+                    Button::GridButton { x: 1, y: 2 },
+                    RgbColor::new(127, 80, 127),
+                ),
+            ])?;
+        }
+    );
+    test!("Control button 2 flashes red", {
+        mk3.flash(Button::ControlButton { index: 2 }, PaletteColor::RED)?;
+    });
+    test!("Control button 3 pulses red", {
+        mk3.pulse(Button::ControlButton { index: 3 }, PaletteColor::RED)?;
+    });
+    test!("Control buttons 4 and 5 flash red", {
+        mk3.flash_multiple([
+            (Button::ControlButton { index: 4 }, PaletteColor::RED),
+            (Button::ControlButton { index: 5 }, PaletteColor::RED),
+        ])?;
+    });
+    test!("Control buttons 6 and 7 pulse red", {
+        mk3.pulse_multiple([
+            (Button::ControlButton { index: 6 }, PaletteColor::RED),
+            (Button::ControlButton { index: 7 }, PaletteColor::RED),
+        ])?;
+    });
+    test!("Grid button (2, 0) flashes red", {
+        mk3.flash(Button::GridButton { x: 2, y: 0 }, PaletteColor::RED)?;
+    });
+    test!("Grid button (3, 0) pulses red", {
+        mk3.pulse(Button::GridButton { x: 3, y: 0 }, PaletteColor::RED)?;
+    });
+    test!("Grid buttons (2, 1) and (2, 2) flash red", {
+        mk3.flash_multiple([
+            (Button::GridButton { x: 2, y: 1 }, PaletteColor::RED),
+            (Button::GridButton { x: 2, y: 2 }, PaletteColor::RED),
+        ])?;
+    });
+    test!("Grid buttons (3, 1) and (3, 2) pulse red", {
+        mk3.pulse_multiple([
+            (Button::GridButton { x: 3, y: 1 }, PaletteColor::RED),
+            (Button::GridButton { x: 3, y: 2 }, PaletteColor::RED),
+        ])?;
+    });
+    test!("Blue text scrolls across the pad", {
+        mk3.scroll_text(b"Hello, world!", PaletteColor::BLUE, 10, true)?;
+    });
+    test!("The scroll has stopped", {
+        mk3.stop_scroll()?;
+    });
+    test!("Grid rows 6 and 7 turn yellow", {
+        mk3.light_rows([(6, PaletteColor::YELLOW), (7, PaletteColor::YELLOW)])?;
+    });
+    test!("Grid columns 6 and 7 turn green", {
+        mk3.light_columns([(6, PaletteColor::GREEN), (7, PaletteColor::GREEN)])?;
+    });
+    test!("Brightness is dimmed", { mk3.set_brightness(20)? });
+    test!("Brightness is restored", { mk3.set_brightness(127)? });
+    test!("LEDs are off", { mk3.send_sleep(SleepMode::Sleep)? });
+    test!("LEDs are restored", { mk3.send_sleep(SleepMode::Wake)? });
+
+    println!("/////////////////////////////////////////////");
+    println!("//  INPUT TESTS");
+    println!("/////////////////////////////////////////////");
+
+    let input = launchy::mini_mk3::Input::guess_polling()?;
+
+    mk3.request_sleep_mode()?;
+    for msg in input.iter() {
+        if let Message::SleepMode(mode) = msg {
+            println!("SleepMode {mode:?}");
+            break;
+        }
+    }
+
+    mk3.request_brightness()?;
+    for msg in input.iter() {
+        if let Message::Brightness(b) = msg {
+            println!("Brightness {b:?}");
+            break;
+        }
+    }
+
+    mk3.request_device_inquiry(DeviceIdQuery::Any)?;
+    for msg in input.iter() {
+        match msg {
+            Message::BootloaderVersion(version) => {
+                println!("The boot loader version is {:?}", version.bytes);
+                break;
+            }
+            Message::ApplicationVersion(version) => {
+                println!("The application version is {:?}", version.bytes);
+                break;
+            }
+            _ => println!("{msg:?}"),
+        }
+    }
+
+    println!("Press and release the PURPLE button at (4, 3)");
+    mk3.light(Button::grid(4, 3), PaletteColor::PURPLE)?;
+
+    let mut did_see_press = false;
+    for msg in input.iter() {
+        match msg {
+            Message::Press(button) if button == Button::grid(4, 3) => {
+                println!("Press");
+                did_see_press = true;
+            }
+            Message::Release(button) if button == Button::grid(4, 3) => {
+                println!("Release");
+                if did_see_press {
+                    break;
+                }
+            }
+            _ => (),
+        }
+    }
+
+    println!("Press buttons on the screen to observe responses; top-left button exits.");
+    println!("(Be sure to try all buttons on the edges)");
+    do_canvas_demo()?;
+
+    println!("All tests done!");
+
+    if !failed_tests.is_empty() {
+        println!("/////////////////////////////////////////////");
+        println!("//  FAILED TESTS");
+        println!("/////////////////////////////////////////////");
+        for failed_test in failed_tests {
+            println!("- {}", failed_test);
+        }
+    }
+
+    Ok(())
+}
+
+fn yes_no() -> Result<bool, std::io::Error> {
+    let mut answer = String::new();
+    loop {
+        answer.clear();
+        stdin().read_line(&mut answer)?;
+        let buf = answer.trim_end().to_lowercase();
+        if buf.is_empty() || buf == "y" {
+            return Ok(true);
+        }
+        if buf == "n" {
+            return Ok(false);
+        }
+        println!("[Y/n] ");
+    }
+}
+
+fn do_canvas_demo() -> Result<(), MidiError> {
+    // Setup devices
+    let (mut canvas, poller) = launchy::CanvasLayout::new_polling();
+    canvas.add_by_guess::<launchy::mini_mk3::Canvas>(0, 0)?;
+    let mut canvas = canvas.into_padded();
+
+    // Do the actual animation. Top-left button stops.
+    for color in (0u64..).map(|f| Color::red_green_color(f as f32 / 60.0 / 2.5)) {
+        for msg in poller.iter_for_millis(17).filter(|msg| msg.is_press()) {
+            println!("Press {:?}", msg.pad());
+            canvas[msg.pad()] = color * 60.0;
+
+            if msg.x() == 0 && msg.y() == 0 {
+                return Ok(());
+            }
+        }
+        canvas.flush()?;
+
+        for pad in canvas.iter() {
+            let surrounding_color = pad
+                .neighbors_5()
+                .iter()
+                .map(|&p| canvas.get(p).unwrap_or(Color::BLACK))
+                .sum::<Color>()
+                / 5.0
+                / 1.05;
+
+            canvas[pad] = canvas[pad].mix(surrounding_color, 0.4);
+        }
+        canvas[Pad { x: 0, y: 0 }] = Color::RED;
+    }
+
+    Ok(())
+}

--- a/src/canvas/generic.rs
+++ b/src/canvas/generic.rs
@@ -178,6 +178,7 @@ impl<Spec: DeviceSpec> crate::Canvas for DeviceCanvas<Spec> {
         if !changes.is_empty() {
             use crate::midi_io::OutputDevice;
             self.num_sent_changes += changes.len();
+
             if self.num_sent_changes / 1000 != (self.num_sent_changes - changes.len()) / 1000 {
                 println!(
                     "{}: we're at {} total transmitted changes now",

--- a/src/canvas/mod.rs
+++ b/src/canvas/mod.rs
@@ -19,15 +19,15 @@ macro_rules! impl_traits_for_canvas {
             type Output = Color;
 
             fn index(&self, pad: Pad) -> &Color {
-                let (x, y) = pad.to_u32().expect("Pad coordinates out of bounds");
-                self.low_level_get(x, y).expect("Pad coordinates out of bounds")
+                let (x, y) = pad.to_u32().unwrap_or_else(|| panic!("Pad coordinates out of bounds (pad to u32: {:?})", pad));
+                self.low_level_get(x, y).unwrap_or_else(|| panic!("Pad coordinates out of bounds: ({}, {})", x, y))
             }
         }
 
         impl<$($a $(: $b)?),*> std::ops::IndexMut<Pad> for $i<$($a),*> {
             fn index_mut(&mut self, pad: Pad) -> &mut Color {
-                let (x, y) = pad.to_u32().expect("Pad coordinates out of bounds");
-                self.low_level_get_pending_mut(x, y).expect("Pad coordinates out of bounds")
+                let (x, y) = pad.to_u32().unwrap_or_else(|| panic!("Pad coordinates out of bounds (pad to u32: {:?})", pad));
+                self.low_level_get_pending_mut(x, y).unwrap_or_else(|| panic!("Pad coordinates out of bounds: ({}, {})", x, y))
             }
         }
 

--- a/src/launchpad_mini_mk3/input.rs
+++ b/src/launchpad_mini_mk3/input.rs
@@ -8,9 +8,9 @@ use super::{Button, Layout, SleepMode};
 /// A Launchpad Mini MK3 input message
 pub enum Message {
     /// A button was pressed
-    Press(Button),
+    Press { button: Button },
     /// A button was released
-    Release(Button),
+    Release { button: Button },
     /// One of the responses to a [device inquiry request](super::Output::request_device_inquiry)
     ApplicationVersion(Version),
     /// One of the responses to a [device inquiry request](super::Output::request_device_inquiry)
@@ -74,8 +74,8 @@ impl crate::InputDevice for Input {
                 let button = decode_grid_button(button);
 
                 match velocity {
-                    0 => Message::Release(button),
-                    127 => Message::Press(button),
+                    0 => Message::Release { button },
+                    127 => Message::Press { button },
                     other => panic!("Unexpected grid note-on velocity {}", other),
                 }
             }
@@ -84,8 +84,8 @@ impl crate::InputDevice for Input {
                 let button = decode_control_button(number);
 
                 match velocity {
-                    0 => Message::Release(button),
-                    127 => Message::Press(button),
+                    0 => Message::Release { button },
+                    127 => Message::Press { button },
                     other => panic!("Unexpected grid note-on velocity {}", other),
                 }
             }
@@ -98,7 +98,7 @@ impl crate::InputDevice for Input {
 
                 let button = decode_grid_button(button);
 
-                Message::Release(button)
+                Message::Release { button }
             }
             // Response to a Device Inquiry
             &[240, 126, 0, 6, 2, 0, 32, 41, 19, 1, 0, 0, v1, v2, v3, v4, 247] => {

--- a/src/launchpad_mini_mk3/input.rs
+++ b/src/launchpad_mini_mk3/input.rs
@@ -1,0 +1,126 @@
+use core::panic;
+
+pub use crate::protocols::query::*;
+
+use super::{Button, Layout, SleepMode};
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+/// A Launchpad Mini MK3 input message
+pub enum Message {
+    /// A button was pressed
+    Press(Button),
+    /// A button was released
+    Release(Button),
+    /// One of the responses to a [device inquiry request](super::Output::request_device_inquiry)
+    ApplicationVersion(Version),
+    /// One of the responses to a [device inquiry request](super::Output::request_device_inquiry)
+    BootloaderVersion(Version),
+    /// The response to initialization commands to change the mode to Programmer mode
+    ChangeLayout(Layout),
+    /// The response to a [sleep mode request](super::Output::request_sleep_mode)
+    SleepMode(SleepMode),
+    /// The response to a [brigtness request](super::Output::request_brightness).
+    Brightness(u8),
+}
+
+/// A version structure
+///
+/// The version is 4 bytes from 0-9.
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+pub struct Version {
+    pub bytes: [u8; 4],
+}
+
+/// The Launchpad Mini MK3 input connection creator.
+pub struct Input;
+
+fn decode_grid_button(btn: u8) -> Button {
+    let x = (btn % 10) - 1;
+    let y = 8 - (btn / 10);
+    Button::GridButton { x, y }
+}
+
+fn decode_control_button(btn: u8) -> Button {
+    // The top control buttons are encoded as 91, 92, 95, 96, 97, 98, while the
+    // right-side control buttons are encoded as 89, 79, 69, 59, 49, 39, 29, 19
+    // (which fits in line with the grid button coordinates).
+    //
+    // In fact, Launchy considers the right-side control buttons as
+    // grid buttons.
+    match btn {
+        91..=98 => Button::ControlButton { index: btn - 91 },
+        19..=89 if btn % 10 == 9 => decode_grid_button(btn),
+        _ => panic!("Unexpected control button value {}", btn),
+    }
+}
+
+impl crate::InputDevice for Input {
+    /// Device name.
+    ///
+    /// On MacOS, the Mini MK3 advertises
+    ///
+    /// - Launchpad Mini MK3 LPMiniMK3 DAW
+    /// - Launchpad Mini MK3 LPMiniMK3 MIDI
+    ///
+    /// But only the MIDI interface works, so include the "MIDI" string.
+    const MIDI_DEVICE_KEYWORD: &'static str = "Launchpad Mini MK3 LPMiniMK3 MIDI";
+    const MIDI_CONNECTION_NAME: &'static str = "Launchy Mini Mk3 Input";
+    type Message = Message;
+
+    fn decode_message(_timestamp: u64, data: &[u8]) -> Message {
+        match data {
+            // Grid button
+            &[0x90, button, velocity] => {
+                let button = decode_grid_button(button);
+
+                match velocity {
+                    0 => Message::Release(button),
+                    127 => Message::Press(button),
+                    other => panic!("Unexpected grid note-on velocity {}", other),
+                }
+            }
+            // Control button
+            &[0xB0, number, velocity] => {
+                let button = decode_control_button(number);
+
+                match velocity {
+                    0 => Message::Release(button),
+                    127 => Message::Press(button),
+                    other => panic!("Unexpected grid note-on velocity {}", other),
+                }
+            }
+            // Implement release (actively used)
+            &[0x80, button, extra] => {
+                // TODO: figure out what extra is, appears to be 0x40 for all buttons
+                if extra != 0x40 {
+                    panic!("Unexpected grid note-off extra byte {}", extra);
+                }
+
+                let button = decode_grid_button(button);
+
+                Message::Release(button)
+            }
+            // Response to a Device Inquiry
+            &[240, 126, 0, 6, 2, 0, 32, 41, 19, 1, 0, 0, v1, v2, v3, v4, 247] => {
+                Message::ApplicationVersion(Version {
+                    bytes: [v1, v2, v3, v4],
+                })
+            }
+            &[240, 126, 0, 6, 2, 0, 32, 41, 19, 17, 0, 0, v1, v2, v3, v4, 247] => {
+                Message::BootloaderVersion(Version {
+                    bytes: [v1, v2, v3, v4],
+                })
+            }
+            // Response to sleep mode query
+            &[240, 0, 32, 41, 2, 13, 9, sleep, 247] => Message::SleepMode(match sleep {
+                0 => SleepMode::Sleep,
+                _ => SleepMode::Wake,
+            }),
+            // Response to layout command
+            &[240, 0, 32, 41, 2, 13, 14, layout, 247] => Message::ChangeLayout(layout.into()),
+            // Response to brightness query
+            &[240, 0, 32, 41, 2, 13, 8, brightness, 247] => Message::Brightness(brightness),
+            other => panic!("Unexpected midi message: {:?}", other),
+        }
+    }
+}

--- a/src/launchpad_mini_mk3/mod.rs
+++ b/src/launchpad_mini_mk3/mod.rs
@@ -1,7 +1,7 @@
 /*!
 # Launchpad Mini MK3 low-level API
 
-![Picture](https://imgur.com/a/oy2iubC.png)
+![Picture](https://imgur.com/ra7nOzc.png)
 
 The Launchpad Mini MK3 has a 9x9 grid with 80 buttons. The top
 row are control buttons, indexed `0..7`. The `launchy` library
@@ -54,11 +54,11 @@ impl crate::DeviceSpec for Spec {
 
     fn convert_message(msg: Message) -> Option<crate::CanvasMessage> {
         match msg {
-            Message::Press(button) => Some(crate::CanvasMessage::Press {
+            Message::Press { button } => Some(crate::CanvasMessage::Press {
                 x: button.abs_x() as u32,
                 y: button.abs_y() as u32,
             }),
-            Message::Release(button) => Some(crate::CanvasMessage::Release {
+            Message::Release { button } => Some(crate::CanvasMessage::Release {
                 x: button.abs_x() as u32,
                 y: button.abs_y() as u32,
             }),

--- a/src/launchpad_mini_mk3/mod.rs
+++ b/src/launchpad_mini_mk3/mod.rs
@@ -1,0 +1,74 @@
+/*!
+# Launchpad Mini MK3 low-level API
+
+![Picture](https://imgur.com/a/oy2iubC.png)
+
+The Launchpad Mini MK3 has a 9x9 grid with 80 buttons. The top
+row are control buttons, indexed `0..7`. The `launchy` library
+considers the right-hand side buttons to be part of the grid,
+so the grid has a size of 9x8.
+*/
+
+mod input;
+pub use input::*;
+
+mod output;
+pub use output::*;
+
+pub use crate::protocols::Button80 as Button;
+
+#[doc(hidden)]
+pub struct Spec;
+
+impl crate::DeviceSpec for Spec {
+    const BOUNDING_BOX_WIDTH: u32 = 9;
+    const BOUNDING_BOX_HEIGHT: u32 = 9;
+    const COLOR_PRECISION: u16 = 128;
+
+    type Input = Input;
+    type Output = Output;
+
+    fn is_valid(x: u32, y: u32) -> bool {
+        if x > 8 || y > 8 {
+            return false;
+        }
+        if x == 8 && y == 0 {
+            return false;
+        }
+        true
+    }
+
+    fn flush(
+        canvas: &mut crate::DeviceCanvas<Self>,
+        changes: &[(u32, u32, (u8, u8, u8))],
+    ) -> Result<(), crate::MidiError> {
+        let changes = changes.iter().map(|&(x, y, (r, g, b))| {
+            let color = RgbColor::new(r, g, b);
+
+            let button = Button::from_abs(x as u8, y as u8);
+
+            (button, color)
+        });
+        canvas.output.light_multiple_rgb(changes)
+    }
+
+    fn convert_message(msg: Message) -> Option<crate::CanvasMessage> {
+        match msg {
+            Message::Press(button) => Some(crate::CanvasMessage::Press {
+                x: button.abs_x() as u32,
+                y: button.abs_y() as u32,
+            }),
+            Message::Release(button) => Some(crate::CanvasMessage::Release {
+                x: button.abs_x() as u32,
+                y: button.abs_y() as u32,
+            }),
+            Message::ApplicationVersion(_)
+            | Message::BootloaderVersion(_)
+            | Message::SleepMode(_)
+            | Message::Brightness(_)
+            | Message::ChangeLayout(_) => None,
+        }
+    }
+}
+
+pub type Canvas<'a> = crate::DeviceCanvas<Spec>;

--- a/src/launchpad_mini_mk3/output.rs
+++ b/src/launchpad_mini_mk3/output.rs
@@ -1,0 +1,884 @@
+use midir::MidiOutputConnection;
+
+pub use crate::protocols::query::*;
+
+use super::Button;
+use crate::OutputDevice;
+
+/// The maximum value of an RGB LED
+const MAX_RGB: u8 = 127;
+
+/// A color from the Mk3 color palette. See the "Launchpad MK3 Programmers Reference Manual"
+/// to see the palette, or [see here](http://launchpaddr.com/mk3palette/).
+///
+/// Everywhere where a PaletteColor is expected as a funcion argument, you can also directly pass
+/// in the palette index and call `.into()` on it. Example:
+/// ```no_run
+/// # use launchy::mini_mk3::{PaletteColor};
+/// # let output: launchy::mini_mk3::Output = unimplemented!();
+/// // This:
+/// output.light_all(PaletteColor::new(92));
+/// // can also be written as:
+/// output.light_all(92.into());
+/// # Ok::<(), launchy::MidiError>(())
+/// ```
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub struct PaletteColor {
+    pub(crate) id: u8,
+}
+
+impl PaletteColor {
+    pub fn is_valid(&self) -> bool {
+        self.id <= 127
+    }
+
+    pub fn new(id: u8) -> Self {
+        let self_ = Self { id };
+        assert!(self_.is_valid());
+        self_
+    }
+
+    pub fn id(&self) -> u8 {
+        self.id
+    }
+    pub fn set_id(&mut self, id: u8) {
+        self.id = id
+    }
+}
+
+impl From<u8> for PaletteColor {
+    fn from(id: u8) -> Self {
+        Self::new(id)
+    }
+}
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+/// An RGB color. Each component may only go up to 63.
+pub struct RgbColor {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+/// The button styles supported by the MK3 Mini
+///
+/// Buttons can be in one of 3 states:
+///
+/// - Plain: a constant color, using either a palette color or an RGB
+///   color.
+/// - Flashing: flashing between two colors on a 50% duty cycle. For
+///   simplicity, [ButtonStyle::flash] flashes between a given color
+///   and black, and [ButtonStyle::flash2] flashes between 2 colors.
+///   Flashing can only use palette colors.
+/// - Pulsing: pulsing between a given (palette) color and black.
+///   Pulsing looks more subdued than flashing.
+///
+/// [PaletteColor] and [RgbColor] are convertible into [ButtonStyle]
+/// using `color.into()`; this will use the plain (non-flashing) button
+/// style.
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub enum ButtonStyle {
+    Palette {
+        color: PaletteColor,
+    },
+    Rgb {
+        color: RgbColor,
+    },
+    Flash {
+        color1: PaletteColor,
+        color2: PaletteColor,
+    },
+    Pulse {
+        color: PaletteColor,
+    },
+}
+
+impl ButtonStyle {
+    /// Create a plain button style from a palette color
+    pub fn palette(color: PaletteColor) -> Self {
+        ButtonStyle::Palette { color }
+    }
+
+    /// Flash between a given color and black
+    pub fn flash(color: PaletteColor) -> Self {
+        Self::flash2(color, PaletteColor::BLACK)
+    }
+
+    /// Flash between a given color and black
+    pub fn flash2(color1: PaletteColor, color2: PaletteColor) -> Self {
+        ButtonStyle::Flash { color1, color2 }
+    }
+
+    /// Pulse the given color (and black)
+    pub fn pulse(color: PaletteColor) -> Self {
+        ButtonStyle::Pulse { color }
+    }
+
+    /// Create a plain button style from an RGB color
+    pub fn rgb(color: RgbColor) -> Self {
+        ButtonStyle::Rgb { color }
+    }
+
+    /// Validate that the button style's colors only use valid numbers
+    pub fn is_valid(&self) -> bool {
+        match self {
+            ButtonStyle::Palette { color } => color.is_valid(),
+            ButtonStyle::Rgb { color } => color.is_valid(),
+            ButtonStyle::Flash { color1, color2 } => color1.is_valid() && color2.is_valid(),
+            ButtonStyle::Pulse { color } => color.is_valid(),
+        }
+    }
+}
+
+impl From<PaletteColor> for ButtonStyle {
+    fn from(color: PaletteColor) -> Self {
+        ButtonStyle::Palette { color }
+    }
+}
+
+impl From<&PaletteColor> for ButtonStyle {
+    fn from(color: &PaletteColor) -> Self {
+        Self::from(*color)
+    }
+}
+
+impl From<RgbColor> for ButtonStyle {
+    fn from(color: RgbColor) -> Self {
+        ButtonStyle::Rgb { color }
+    }
+}
+
+impl From<&RgbColor> for ButtonStyle {
+    fn from(color: &RgbColor) -> Self {
+        Self::from(*color)
+    }
+}
+
+impl RgbColor {
+    /// Create a new RgbColor from the individual component values
+    pub fn new(r: u8, g: u8, b: u8) -> Self {
+        let self_ = Self { r, g, b };
+        assert!(self_.is_valid());
+        self_
+    }
+
+    /// Check whether the rgb color is valid - each component may only go up to MAX_RGB.
+    pub fn is_valid(&self) -> bool {
+        self.r <= MAX_RGB && self.g <= MAX_RGB && self.b <= MAX_RGB
+    }
+
+    pub fn red(&self) -> u8 {
+        self.r
+    }
+    pub fn green(&self) -> u8 {
+        self.g
+    }
+    pub fn blue(&self) -> u8 {
+        self.b
+    }
+    pub fn set_red(&mut self, r: u8) {
+        assert!(r <= MAX_RGB);
+        self.r = r
+    }
+    pub fn set_green(&mut self, g: u8) {
+        assert!(g <= MAX_RGB);
+        self.g = g
+    }
+    pub fn set_blue(&mut self, b: u8) {
+        assert!(b <= MAX_RGB);
+        self.b = b
+    }
+}
+
+impl PaletteColor {
+    // These are some commonly used colors as palette colors. I don't have Rgb colors as constants
+    // because in the case of rgb colors you can just make your required colors yourself
+
+    // Basic colors, the top row
+    pub const BLACK: PaletteColor = Self { id: 0 };
+    pub const DARK_GRAY: PaletteColor = Self { id: 1 };
+    pub const LIGHT_GRAY: PaletteColor = Self { id: 2 };
+    pub const WHITE: PaletteColor = Self { id: 3 };
+
+    // Third column from the right
+    pub const LIGHT_RED: PaletteColor = Self { id: 4 };
+    pub const RED: PaletteColor = Self { id: 5 };
+    pub const ORANGE: PaletteColor = Self { id: 9 };
+    pub const YELLOW: PaletteColor = Self { id: 13 };
+    pub const LIME_GREEN: PaletteColor = Self { id: 17 };
+    pub const GREEN: PaletteColor = Self { id: 21 };
+    pub const SLIGHTLY_LIGHT_GREEN: PaletteColor = Self { id: 29 };
+    pub const LIGHT_BLUE: PaletteColor = Self { id: 37 };
+    pub const BLUE: PaletteColor = Self { id: 45 };
+    pub const PURPLE: PaletteColor = Self { id: 49 };
+    pub const MAGENTA: PaletteColor = Self { id: 53 };
+    pub const PINK: PaletteColor = Self { id: 57 };
+    pub const BROWN: PaletteColor = Self { id: 61 };
+
+    // This is not belonging to any of the columns/rows but included anyway cuz cyan is important
+    pub const CYAN: PaletteColor = Self { id: 90 };
+}
+
+/// The Mini Mk3 can light a button in different ways
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum LightMode {
+    /// This is the standard mode. A straight consistent light
+    Plain,
+    /// A flashing motion On->Off->On->Off->...
+    Flash,
+    /// A smooth pulse
+    Pulse,
+}
+
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum SleepMode {
+    Sleep = 0,
+    Wake = 1,
+}
+
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum Layout {
+    Live = 0, // reserved for Ableton Live, shouldn't be used here
+    Programmer = 1,
+}
+
+impl From<u8> for Layout {
+    fn from(id: u8) -> Self {
+        match id {
+            0 => Self::Live,
+            1 => Self::Programmer,
+            _ => panic!("Unexpected layout id {}", id),
+        }
+    }
+}
+
+/// The object handling any messages _to_ the launchpad. To get started, initialize with
+/// [(`Output::guess`)[OutputDevice::guess]] and then send messages to your liking. The connection
+/// to the launchpad will get closed when this object goes out of scope.
+///
+/// For example:
+/// ```no_run
+/// # use launchy::OutputDevice as _;
+/// # use launchy::mk3::{PaletteColor, Button, Output};
+/// let mut output = Output::guess()?;
+///
+/// output.light_all(PaletteColor::BLACK); // clear screen
+///
+/// // make a red cross in the center
+/// output.light_row(4, PaletteColor::RED);
+/// output.light_row(5, PaletteColor::RED);
+/// output.light_column(4, PaletteColor::RED);
+/// output.light_column(5, PaletteColor::RED);
+///
+/// // light top left button magenta
+/// output.light(Button::GridButton { x: 0, y: 0 }, PaletteColor::MAGENTA);
+/// # Ok::<(), launchy::MidiError>(())
+/// ```
+///
+/// # Representing color
+/// The Launchpad Mk3 has two different ways to represent color. You can either use one of the 128
+/// built-in palette colors, or you can create a custom color with custom rgb components.
+/// Why would you choose the palette colors when you can just create your required colors yourself?
+/// Well some operations on the Mk3 only support palette colors. Besides, sending palette color midi
+/// messages is simply faster. Therefore you should aim to use the palette colors when possible.
+pub struct Output {
+    connection: MidiOutputConnection,
+}
+
+impl crate::OutputDevice for Output {
+    const MIDI_CONNECTION_NAME: &'static str = "Launchy Mini Mk3 output";
+
+    /// Device name.
+    ///
+    /// On MacOS, the Mini MK3 advertises:
+    ///
+    /// - "Launchpad Mini MK3 LPMiniMK3 DAW"
+    /// - "Launchpad Mini MK3 LPMiniMK3 MIDI"
+    ///
+    /// But only the MIDI interface works for what we want to do, so include the "MIDI" string.
+    const MIDI_DEVICE_KEYWORD: &'static str = "Launchpad Mini MK3 LPMiniMK3 MIDI";
+
+    fn from_connection(connection: MidiOutputConnection) -> Result<Self, crate::MidiError> {
+        let mut self_ = Self { connection };
+        self_.change_layout(Layout::Programmer)?;
+        Ok(self_)
+    }
+
+    fn send(&mut self, bytes: &[u8]) -> Result<(), crate::MidiError> {
+        self.connection.send(bytes)?;
+        Ok(())
+    }
+}
+
+impl Output {
+    /// Set a `button` to a certain `color` with a certain `light_mode`.
+    ///
+    /// This uses a direct MIDI message on channel 1, 2 or 3 to set the color,
+    /// and uses different data structures than `set_buttons` (which uses a
+    /// SysEx message that also allows RGB button colors and flashing between 2
+    /// different palette colors).
+    ///
+    /// For example to start a yellow pulse on the leftmost control button:
+    /// ```no_run
+    /// # use launchy::mk3::{PaletteColor, Button, LightMode};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// let button = Button::ControlButton { index: 0 };
+    /// let color = PaletteColor::YELLOW;
+    /// let light_mode = LightMode::Pulse;
+    /// output.set_button(button, color, light_mode)?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn set_button(
+        &mut self,
+        button: Button,
+        color: PaletteColor,
+        light_mode: LightMode,
+    ) -> Result<(), crate::MidiError> {
+        assert!(color.id <= 127);
+
+        let type_byte = match button {
+            Button::GridButton { .. } => 0x90,
+            Button::ControlButton { .. } => 0xB0,
+        } + match light_mode {
+            LightMode::Plain => 0,
+            LightMode::Flash => 1,
+            LightMode::Pulse => 2,
+        };
+
+        self.send(&[type_byte, Self::encode_button(button), color.id])
+    }
+
+    /// Light multiple buttons with varying colors.
+    ///
+    /// This uses a SysEx message to set one or more buttons in one go, and supports
+    /// RGB colors as well as flashing between 2 colors.
+    ///
+    /// Apart from `set_button` which uses a simpler mechanism to set button colors,
+    /// all other lighting control methods forward to this one.
+    ///
+    /// For example to light the top left button green and the top right button red:
+    /// ```no_run
+    /// # use launchy::mk3::{Button, RgbColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.set_buttons(&[
+    ///     (Button::GridButton { x: 0, y: 0 }, ButtonStyle::rgb(RgbColor::new(0, 0, 127))),
+    ///     (Button::GridButton { x: 7, y: 0 }, RgbColor::new(127, 0, 0).into()),
+    /// ])?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn set_buttons<I, T>(&mut self, buttons: I) -> Result<(), crate::MidiError>
+    where
+        I: IntoIterator<Item = T>,
+        T: std::borrow::Borrow<(Button, ButtonStyle)>,
+    {
+        let buttons = buttons.into_iter();
+
+        assert!(buttons.size_hint().0 <= 81);
+
+        let mut bytes = Vec::with_capacity(8 + 5 * buttons.size_hint().1.unwrap_or(40));
+
+        // SysEx message
+        bytes.extend(&[240, 0, 32, 41, 2, 13, 3]);
+        for pair in buttons {
+            let (button, style) = pair.borrow();
+            assert!(style.is_valid());
+            match style {
+                ButtonStyle::Palette { color } => {
+                    bytes.extend([0, Self::encode_button(*button), color.id()])
+                }
+                ButtonStyle::Rgb { color } => bytes.extend([
+                    3,
+                    Self::encode_button(*button),
+                    color.red(),
+                    color.green(),
+                    color.blue(),
+                ]),
+                ButtonStyle::Flash { color1, color2 } => {
+                    // Order color2 and color1 such that (1=red, 2=black) looks exactly
+                    // the same as a legacy flash red (as configured by `set_button`).
+                    bytes.extend([1, Self::encode_button(*button), color2.id(), color1.id()])
+                }
+                ButtonStyle::Pulse { color } => {
+                    bytes.extend([2, Self::encode_button(*button), color.id()])
+                }
+            }
+        }
+        bytes.push(247);
+
+        self.send(&bytes)
+    }
+
+    /// Light multiple buttons with varying RGB colors.
+    ///
+    /// For example to light the top left button green and the top right button red:
+    ///
+    /// ```no_run
+    /// # use launchy::mk3::{Button, RgbColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.light_multiple_rgb(&[
+    ///     (Button::GridButton { x: 0, y: 0 }, RgbColor::new(0, 0, 127)),
+    ///     (Button::GridButton { x: 7, y: 0 }, RgbColor::new(127, 0, 0)),
+    /// ])?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    ///
+    /// The implementation of this method forwards the call to [Output::set_buttons].
+    pub fn light_multiple_rgb<I, T>(&mut self, buttons: I) -> Result<(), crate::MidiError>
+    where
+        I: IntoIterator<Item = T>,
+        T: std::borrow::Borrow<(Button, RgbColor)>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        self.set_buttons(
+            buttons
+                .into_iter()
+                .map(|pair| *pair.borrow())
+                .map(|(button, color)| (button, color.into())),
+        )
+    }
+
+    /// Light multiple columns with varying colors. This method does not light up the control
+    /// buttons
+    ///
+    /// For example to light the first column yellow and the second column blue:
+    /// ```no_run
+    /// # use launchy::mk3::{Button, PaletteColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.light_columns(&[
+    ///     (0, PaletteColor::YELLOW),
+    ///     (1, PaletteColor::BLUE),
+    /// ])?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn light_columns(
+        &mut self,
+        buttons: impl IntoIterator<Item = impl std::borrow::Borrow<(u8, PaletteColor)>>,
+    ) -> Result<(), crate::MidiError> {
+        self.set_buttons(
+            buttons
+                .into_iter()
+                .map(|pair| *pair.borrow())
+                .flat_map(|(col, color)| {
+                    column_buttons(col).map(move |button| (button, color.into()))
+                }),
+        )
+    }
+
+    /// Light multiple row with varying colors. This method _does_ light up the side buttons.
+    ///
+    /// Note: the row are counted starting at the control row! For example to light the control row
+    /// magenta and the first grid row green:
+    /// ```no_run
+    /// # use launchy::mk3::{Button, PaletteColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.light_rows(&[
+    ///     (0, PaletteColor::MAGENTA),
+    ///     (1, PaletteColor::GREEN),
+    /// ])?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn light_rows(
+        &mut self,
+        buttons: impl IntoIterator<Item = impl std::borrow::Borrow<(u8, PaletteColor)>>,
+    ) -> Result<(), crate::MidiError> {
+        self.set_buttons(
+            buttons
+                .into_iter()
+                .map(|pair| *pair.borrow())
+                .flat_map(|(row, color)| {
+                    row_buttons(row).map(move |button| (button, color.into()))
+                }),
+        )
+    }
+
+    /// Light all buttons, including control and side buttons.
+    ///
+    /// For example to clear the screen:
+    /// ```no_run
+    /// # use launchy::mk3::PaletteColor;
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.light_all(PaletteColor::BLACK)?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn light_all(&mut self, color: PaletteColor) -> Result<(), crate::MidiError> {
+        let mut buffer = vec![240, 0, 32, 41, 2, 13, 3];
+
+        for row in 1..10 {
+            for column in 1..10 {
+                buffer.push(0);
+
+                buffer.push(row * 10 + column);
+
+                buffer.push(color.id);
+            }
+        }
+
+        buffer.push(247);
+
+        self.send(&buffer)
+    }
+
+    /// By default, Launchpad MK3 will flash and pulse at 120 BPM. This can be altered by sending
+    /// these clock ticks by calling `send_clock_tick()`. These ticks should be sent at a rate of 24
+    /// per beat.
+    ///
+    /// To set a tempo of 100 BPM, 2400 clock ticks should be sent each minute, or with a time
+    /// interval of 25ms.
+    ///
+    /// Launchpad MK3 supports tempos between 40 and 240 BPM, faster clock ticks are apparently
+    /// ignored.
+    ///
+    /// For example to send clock ticks at 200 BPM:
+    /// ```no_run
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// let beats_per_minute = 200;
+    /// let clock_ticks_per_second = beats_per_minute * 60 * 24;
+    /// let clock_tick_interval = std::time::Duration::from_millis(1000 / clock_ticks_per_second);
+    /// loop {
+    ///     output.send_clock_tick()?;
+    ///     std::thread::sleep(clock_tick_interval);
+    /// }
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn send_clock_tick(&mut self) -> Result<(), crate::MidiError> {
+        self.send(&[248, 0, 0])
+    }
+
+    /// Requests the Launchpad Mk3 to send a so-called device inquiry. The device inquiry contains
+    /// information about the device ID and the firmware revision number.
+    ///
+    /// According to the documentation, this should return both a
+    /// [super::Message::ApplicationVersion] as well as a [super::Message::BootloaderVersion].
+    ///
+    /// In order to be able to receive the Launchpad Mk3's response to this
+    /// request, you must have a Launchpad Mk3 input object set up.
+    pub fn request_device_inquiry(&mut self, query: DeviceIdQuery) -> Result<(), crate::MidiError> {
+        request_device_inquiry(self, query)
+    }
+
+    /// Requests the Launchpad Mk3 to send a `Message::SleepState` message.
+    ///
+    /// In order to be able to receive the Launchpad Mk3's response to this request,
+    /// you must have a Launchpad Mk3 input object set up.
+    pub fn request_sleep_mode(&mut self) -> Result<(), crate::MidiError> {
+        self.send(&[240, 0, 32, 41, 2, 13, 9, 247])
+    }
+
+    /// Starts a text scroll across the screen.
+    ///
+    /// The screen is temporarily cleared. You can specify the color of the text
+    /// and whether the text should loop indefinitely.
+    ///
+    /// Speed is given in pads/second, and must be in range (0..128). 16 is
+    /// already quite a brisk speed. If speed is >= 64, it is interpreted as a
+    /// negative number, formed by subtracing 128 from it. This will make the
+    /// text scroll from left to right.
+    ///
+    /// If text is the empty string, the attributes of the currently ongoing
+    /// scroll will be changed instead (color, speed, looping).
+    ///
+    /// When the text ends, Launchpad MK3 restores the LEDs to their previous
+    /// settings.
+    ///
+    /// WARNING: the Mini MK3 does not seem to have a Message that tells you
+    /// when the text is finished. As such, you will have to do time
+    /// calculations yourself to know when your text has finished scrolling.
+    /// If your text loops, you must call [Output::stop_scroll] at some point.
+    ///
+    /// For example to scroll the text "Hello, world!" in blue:
+    ///
+    /// ```no_run
+    /// # use launchy::mk3::PaletteColor;
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.scroll_text(b"Hello, world!", PaletteColor::BLUE, 32, false)?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn scroll_text(
+        &mut self,
+        text: &[u8],
+        color: PaletteColor,
+        speed: u8,
+        should_loop: bool,
+    ) -> Result<(), crate::MidiError> {
+        assert!((0..128).contains(&speed));
+        let bytes = &[
+            &[
+                240,
+                0,
+                32,
+                41,
+                2,
+                13,
+                7,
+                should_loop as u8,
+                speed,
+                // Palette color
+                0,
+                color.id(),
+            ],
+            text,
+            &[247],
+        ]
+        .concat();
+
+        self.send(bytes)
+    }
+
+    /// Stop the ongoing text scroll immediately
+    pub fn stop_scroll(&mut self) -> Result<(), crate::MidiError> {
+        self.send(&[240, 0, 32, 41, 2, 13, 7 /* No text */, 247])
+    }
+
+    pub fn send_sleep(&mut self, sleep_mode: SleepMode) -> Result<(), crate::MidiError> {
+        self.send(&[240, 0, 32, 41, 2, 13, 9, sleep_mode as u8, 247])
+    }
+
+    // /// Force the Launchpad MK3 into bootloader mode
+    // pub fn enter_bootloader(&mut self) -> Result<(), crate::MidiError> {
+    //     self.send(&[240, 0, 32, 41, 0, 113, 0, 105, 247])
+    // }
+
+    /// Set Board mode
+    /// This is required for the mini mk3 to function properly
+    ///
+    /// For example to swap the board to programmer mode:
+    /// ```no_run
+    /// # use launchy::mini_mk3::{Layout};
+    /// # let output: launchy::mini_mk3::Output = unimplemented!();
+    /// let layout_mode = Layout::Programmer;
+    /// output.change_layout(layout_mode)?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    fn change_layout(&mut self, layout: Layout) -> Result<(), crate::MidiError> {
+        self.send(&[240, 0, 32, 41, 2, 13, 14, layout as u8, 247])
+    }
+
+    fn encode_button(button: Button) -> u8 {
+        match button {
+            Button::GridButton { x, y } => {
+                assert!(x <= 8);
+                assert!(y <= 7);
+
+                10 * (8 - y) + x + 1
+            }
+            Button::ControlButton { index } => {
+                assert!(index <= 15);
+
+                if index <= 7 {
+                    index + 91
+                } else {
+                    (8 - (index - 8)) * 10 + 9
+                }
+            }
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Below this point are shorthand function
+    // --------------------------------------------------------------------------------------------
+
+    /// Put the Launchpad MK3 to sleep
+    pub fn sleep(&mut self) -> Result<(), crate::MidiError> {
+        self.send_sleep(SleepMode::Sleep)
+    }
+
+    /// Wake the device up from sleep mode
+    pub fn wake(&mut self) -> Result<(), crate::MidiError> {
+        self.send_sleep(SleepMode::Wake)
+    }
+
+    /// Light a button with a color from the Mk3 palette. Identical to
+    /// `set_button(<button>, <color>, LightMode::Plain)`.
+    ///
+    /// For example to light the "Volume" side button cyan:
+    ///
+    /// ```no_run
+    /// # use launchy::mk3::{Button, PaletteColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.light(Button::VOLUME, PaletteColor::CYAN)?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn light(&mut self, button: Button, color: PaletteColor) -> Result<(), crate::MidiError> {
+        self.set_button(button, color, LightMode::Plain)
+    }
+
+    /// Starts a flashing motion between the previously shown color on this button and palette color
+    /// `color`, with a duty cycle of 50% and a bpm of 120. The bpm can be controlled using
+    /// `send_clock_tick()`.
+    ///
+    /// Identical to `set_button(<button>, <color>, LightMode::FLASH)`.
+    ///
+    /// For example to start a red flash on the "Session" button at the top:
+    /// ```no_run
+    /// # use launchy::mk3::{Button, PaletteColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.flash(Button::UP, PaletteColor::RED)?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn flash(&mut self, button: Button, color: PaletteColor) -> Result<(), crate::MidiError> {
+        self.set_button(button, color, LightMode::Flash)
+    }
+
+    /// Start a pulse; a rhythmic increase and decreases in brightness. The speed can be controlled
+    /// using `send_clock_tick()`. Identical to `set_button(<button>, <color>, LightMode::PULSE)`.
+    ///
+    /// For example to start a magenta pulse on the top right grid button:
+    /// ```no_run
+    /// # use launchy::mk3::{Button, PaletteColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.pulse(Button::GridButton { x: 7, y: 0 }, PaletteColor::MAGENTA)?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn pulse(&mut self, button: Button, color: PaletteColor) -> Result<(), crate::MidiError> {
+        self.set_button(button, color, LightMode::Pulse)
+    }
+
+    /// Light a single column, specified by `column` (0-8).
+    ///
+    /// For example to light the entire side button column white:
+    /// ```no_run
+    /// # use launchy::mk3::{Button, PaletteColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.light_column(8, PaletteColor::WHITE)?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn light_column(
+        &mut self,
+        column: u8,
+        color: PaletteColor,
+    ) -> Result<(), crate::MidiError> {
+        self.light_columns([(column, color)])
+    }
+
+    /// Light a single row, specified by `row` (0-8). Note: the row counting begins at the control
+    /// row! So e.g. when you want to light the first grid row, pass `1` not `0`.
+    ///
+    /// For example to light the first grid row green:
+    /// ```no_run
+    /// # use launchy::mk3::{Button, PaletteColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.light_row(1, PaletteColor::GREEN)?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn light_row(&mut self, row: u8, color: PaletteColor) -> Result<(), crate::MidiError> {
+        self.light_rows([(row, color)])
+    }
+
+    /// Light a single button with an RGB color.
+    ///
+    /// For example to light the bottom right button cyan:
+    /// ```no_run
+    /// # use launchy::mk3::{Button, RgbColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.light_rgb(Button::GridButton { x: 7, y: 7 }, RgbColor::new(0, 127, 127))?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn light_rgb(&mut self, button: Button, color: RgbColor) -> Result<(), crate::MidiError> {
+        self.light_multiple_rgb([(button, color)])
+    }
+
+    /// Light multiple buttons with varying colors. Identical to
+    /// `set_buttons(<pairs>, LightMode::Plain)`
+    ///
+    /// For example to light both User 1 and User 2 buttons orange:
+    /// ```no_run
+    /// # use launchy::mk3::{Button, PaletteColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.light_multiple(&[
+    ///     (Button::USER_1, PaletteColor::new(9)),
+    ///     (Button::USER_2, PaletteColor::new(9)),
+    /// ])?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn light_multiple(
+        &mut self,
+        buttons: impl IntoIterator<Item = impl std::borrow::Borrow<(Button, PaletteColor)>>,
+    ) -> Result<(), crate::MidiError> {
+        self.set_buttons(
+            buttons
+                .into_iter()
+                .map(|pair| *pair.borrow())
+                .map(|(button, color)| (button, color.into())),
+        )
+    }
+
+    /// Start flashing multiple buttons with varying colors. Identical to
+    /// `set_buttons(<pairs>, LightMode::Flash)`
+    ///
+    /// For example to flash both User 1 and User 2 buttons orange:
+    /// ```no_run
+    /// # use launchy::mk3::{Button, PaletteColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.flash_multiple(&[
+    ///     (Button::USER_1, PaletteColor::new(9)),
+    ///     (Button::USER_2, PaletteColor::new(9)),
+    /// ])?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn flash_multiple(
+        &mut self,
+        buttons: impl IntoIterator<Item = impl std::borrow::Borrow<(Button, PaletteColor)>>,
+    ) -> Result<(), crate::MidiError> {
+        self.set_buttons(
+            buttons
+                .into_iter()
+                .map(|pair| *pair.borrow())
+                .map(|(button, color)| (button, ButtonStyle::flash(color))),
+        )
+    }
+
+    /// Start pulsing multiple buttons with varying colors. Identical to
+    /// `set_buttons(<pairs>, LightMode::Pulse)`
+    ///
+    /// For example to pulse both User 1 and User 2 buttons orange:
+    /// ```no_run
+    /// # use launchy::mk3::{Button, PaletteColor};
+    /// # let output: launchy::mk3::Output = unimplemented!();
+    /// output.pulse_multiple(&[
+    ///     (Button::USER_1, PaletteColor::new(9)),
+    ///     (Button::USER_2, PaletteColor::new(9)),
+    /// ])?;
+    /// # Ok::<(), launchy::MidiError>(())
+    /// ```
+    pub fn pulse_multiple(
+        &mut self,
+        buttons: impl IntoIterator<Item = impl std::borrow::Borrow<(Button, PaletteColor)>>,
+    ) -> Result<(), crate::MidiError> {
+        self.set_buttons(
+            buttons
+                .into_iter()
+                .map(|pair| *pair.borrow())
+                .map(|(button, color)| (button, ButtonStyle::pulse(color))),
+        )
+    }
+
+    /// Set the LED brightness on a scale of (0..128) (exclusive).
+    pub fn set_brightness(&mut self, brightness: u8) -> Result<(), crate::MidiError> {
+        assert!((0..128).contains(&brightness));
+        self.send(&[240, 0, 32, 41, 2, 13, 8, brightness, 247])
+    }
+
+    /// Requests a [super::Message::Brightness]
+    pub fn request_brightness(&mut self) -> Result<(), crate::MidiError> {
+        self.send(&[240, 0, 32, 41, 2, 13, 8, 247])
+    }
+
+    /// Clears the entire field of buttons. Equivalent to `output.light_all(PaletteColor::BLACK)`.
+    pub fn clear(&mut self) -> Result<(), crate::MidiError> {
+        self.light_all(PaletteColor::BLACK)
+    }
+}
+
+/// Returns an iterator for all buttons in the given column
+fn column_buttons(x: u8) -> impl Iterator<Item = Button> {
+    (0..8).map(move |y| Button::GridButton { x, y })
+}
+
+/// Returns an iterator for all buttons in the given row
+///
+/// Includes the arrow buttons on the right-hand side
+fn row_buttons(y: u8) -> impl Iterator<Item = Button> {
+    (0..8)
+        .map(move |x| Button::GridButton { x, y })
+        .chain([Button::ControlButton { index: 8 + y }])
+}

--- a/src/launchpad_mini_mk3/output.rs
+++ b/src/launchpad_mini_mk3/output.rs
@@ -60,6 +60,42 @@ pub struct RgbColor {
     b: u8,
 }
 
+impl RgbColor {
+    /// Create a new RgbColor from the individual component values
+    pub fn new(r: u8, g: u8, b: u8) -> Self {
+        let self_ = Self { r, g, b };
+        assert!(self_.is_valid());
+        self_
+    }
+
+    /// Check whether the rgb color is valid - each component may only go up to MAX_RGB.
+    pub fn is_valid(&self) -> bool {
+        self.r <= MAX_RGB && self.g <= MAX_RGB && self.b <= MAX_RGB
+    }
+
+    pub fn red(&self) -> u8 {
+        self.r
+    }
+    pub fn green(&self) -> u8 {
+        self.g
+    }
+    pub fn blue(&self) -> u8 {
+        self.b
+    }
+    pub fn set_red(&mut self, r: u8) {
+        assert!(r <= MAX_RGB);
+        self.r = r
+    }
+    pub fn set_green(&mut self, g: u8) {
+        assert!(g <= MAX_RGB);
+        self.g = g
+    }
+    pub fn set_blue(&mut self, b: u8) {
+        assert!(b <= MAX_RGB);
+        self.b = b
+    }
+}
+
 /// The button styles supported by the MK3 Mini
 ///
 /// Buttons can be in one of 3 states:
@@ -151,42 +187,6 @@ impl From<RgbColor> for ButtonStyle {
 impl From<&RgbColor> for ButtonStyle {
     fn from(color: &RgbColor) -> Self {
         Self::from(*color)
-    }
-}
-
-impl RgbColor {
-    /// Create a new RgbColor from the individual component values
-    pub fn new(r: u8, g: u8, b: u8) -> Self {
-        let self_ = Self { r, g, b };
-        assert!(self_.is_valid());
-        self_
-    }
-
-    /// Check whether the rgb color is valid - each component may only go up to MAX_RGB.
-    pub fn is_valid(&self) -> bool {
-        self.r <= MAX_RGB && self.g <= MAX_RGB && self.b <= MAX_RGB
-    }
-
-    pub fn red(&self) -> u8 {
-        self.r
-    }
-    pub fn green(&self) -> u8 {
-        self.g
-    }
-    pub fn blue(&self) -> u8 {
-        self.b
-    }
-    pub fn set_red(&mut self, r: u8) {
-        assert!(r <= MAX_RGB);
-        self.r = r
-    }
-    pub fn set_green(&mut self, g: u8) {
-        assert!(g <= MAX_RGB);
-        self.g = g
-    }
-    pub fn set_blue(&mut self, b: u8) {
-        assert!(b <= MAX_RGB);
-        self.b = b
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,9 @@ pub use launchpad_mini as mini;
 pub mod launchpad_mk2;
 pub use launchpad_mk2 as mk2;
 
+pub mod launchpad_mini_mk3;
+pub use launchpad_mini_mk3 as mini_mk3;
+
 pub mod launch_control;
 pub use launch_control as control;
 /// The MIDI API of the classic Launch Control and the Launch Control XL is identical

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -14,8 +14,32 @@ impl Button80 {
     pub const LEFT: Self = Button80::ControlButton { index: 2 };
     pub const RIGHT: Self = Button80::ControlButton { index: 3 };
     pub const SESSION: Self = Button80::ControlButton { index: 4 };
+
+    /**
+     * The 6th top-row button
+     *
+     * On the MK2 and the S, this button is called "User 1".
+     *
+     * On the MK3 Mini, this button is called "Drums".
+     */
     pub const USER_1: Self = Button80::ControlButton { index: 5 };
+
+    /**
+     * The 7th top-row button
+     *
+     * On the MK2 and the S, this button is called "User 2".
+     *
+     * On the MK3 Mini, this button is called "Keys".
+     */
     pub const USER_2: Self = Button80::ControlButton { index: 6 };
+
+    /**
+     * The 8th top-row button
+     *
+     * On the MK2 and the S, this button is called "Mixer".
+     *
+     * On the MK3 Mini, this button is called "User".
+     */
     pub const MIXER: Self = Button80::ControlButton { index: 7 };
     pub const VOLUME: Self = Button80::GridButton { x: 8, y: 0 };
     pub const PAN: Self = Button80::GridButton { x: 8, y: 1 };
@@ -25,6 +49,16 @@ impl Button80 {
     pub const MUTE: Self = Button80::GridButton { x: 8, y: 5 };
     pub const SOLO: Self = Button80::GridButton { x: 8, y: 6 };
     pub const RECORD_ARM: Self = Button80::GridButton { x: 8, y: 7 };
+
+    /// Creates a new GridButton coordinate
+    pub fn grid(x: u8, y: u8) -> Button80 {
+        Button80::GridButton { x, y }
+    }
+
+    /// Creates a new ControlButton coordinate
+    pub fn control(index: u8) -> Button80 {
+        Button80::ControlButton { index }
+    }
 
     /// Creates a new button out of absolute coordinates, like the ones returned by `abs_x()` and
     /// `abs_y()`.


### PR DESCRIPTION
This PR adds support for the Mini MK3. It has been based on previous PR #13, but I've had to make rather large changes to the PR.

- The `test_api()` function has been moved into a separate example, `validate-mini-mk3`, which is intended to test/demontrate the functionality and interactively make sure everything works as intended.
- The MK3 has 2 ways of configuring LEDs: the "legacy" method using MIDI channels 1, 2, and 3, and the "SysEx" method where multiple buttons are configured at once, which supports RGB and 2-color flashing. The `set_button` function implements the old method, while `set_buttons` implements the new method. All other functions are convenience functions that forward to the `set_buttons` function.
- To support `set_buttons` a new type has been added: `ButtonStyle`.
- According to the manual, inline text speed control does not work anymore. Instead, text has a single speed.
- Added `stop_scroll`, `set_brightness`, `request_brightness`, `request_sleep_mode`.
- Removed `reqeust_version_inquiry` as this doesn't exist on the MK3.
- RGB resolution has gone from `64` to `128`.
- Changed the button message style from `Message::Release { button: Button }` to `Message::Release(Button)`.
- Add convenience constructors to `Button80` to create them more succinctly: `Button::grid(...)`, `Button::control(...)`.

Resolves #12, closes #13.