### PR TITLE
refactor!: change Button80 into LogicalButton/PhysicalButton

### DIFF
--- a/src/launch_control/mod.rs
+++ b/src/launch_control/mod.rs
@@ -10,6 +10,9 @@ pub use input::*;
 mod output;
 pub use output::*;
 
+use crate::prelude::{LogicalButton, PhysicalButton};
+use crate::shared::{default_logical_to_physical, default_physical_to_logical};
+
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub struct Template(u8);
 
@@ -108,6 +111,14 @@ impl crate::DeviceSpec for Spec {
             return false;
         }
         true
+    }
+
+    fn to_physical(button: LogicalButton) -> PhysicalButton {
+        default_logical_to_physical(button)
+    }
+
+    fn to_logical(button: PhysicalButton) -> Option<LogicalButton> {
+        default_physical_to_logical::<Self>(button)
     }
 
     fn setup(output: &mut Self::Output) -> Result<(), crate::MidiError> {

--- a/src/launchpad_mk2/output.rs
+++ b/src/launchpad_mk2/output.rs
@@ -463,13 +463,12 @@ impl Output {
     where
         I: IntoIterator<Item = T>,
         T: std::borrow::Borrow<(Button, RgbColor)>,
-        I::IntoIter: ExactSizeIterator,
     {
         let buttons = buttons.into_iter();
 
         assert!(buttons.size_hint().0 <= 80);
 
-        let mut bytes = Vec::with_capacity(8 + 12 * buttons.len());
+        let mut bytes = Vec::with_capacity(8 + 12 * buttons.size_hint().1.unwrap_or(40));
 
         bytes.extend(&[240, 0, 32, 41, 2, 24, 11]);
         for pair in buttons {

--- a/src/launchpad_s/mod.rs
+++ b/src/launchpad_s/mod.rs
@@ -10,7 +10,11 @@ pub use input::*;
 mod output;
 pub use output::*;
 
-pub use crate::protocols::Button80 as Button;
+pub use crate::protocols::LogicalButton as Button;
+use crate::{
+    prelude::PhysicalButton,
+    shared::{default_logical_to_physical, default_physical_to_logical},
+};
 
 #[doc(hidden)]
 pub struct Spec;
@@ -31,6 +35,14 @@ impl crate::DeviceSpec for Spec {
             return false;
         }
         true
+    }
+
+    fn to_physical(button: Button) -> PhysicalButton {
+        default_logical_to_physical(button)
+    }
+
+    fn to_logical(button: PhysicalButton) -> Option<Button> {
+        default_physical_to_logical::<Self>(button)
     }
 
     fn flush(
@@ -87,9 +99,9 @@ impl crate::DeviceSpec for Spec {
             )?;
         } else {
             for &(x, y, (r, g, _b)) in changes {
-                canvas
-                    .output
-                    .light(Button::from_abs(x as u8, y as u8), Color::new(r, g))?;
+                if let Some(b) = Self::to_logical(PhysicalButton::new(x, y)) {
+                    canvas.output.light(b, Color::new(r, g))?;
+                }
             }
         }
 
@@ -98,14 +110,14 @@ impl crate::DeviceSpec for Spec {
 
     fn convert_message(msg: Message) -> Option<crate::CanvasMessage> {
         match msg {
-            Message::Press { button } => Some(crate::CanvasMessage::Press {
-                x: button.abs_x() as u32,
-                y: button.abs_y() as u32,
-            }),
-            Message::Release { button } => Some(crate::CanvasMessage::Release {
-                x: button.abs_x() as u32,
-                y: button.abs_y() as u32,
-            }),
+            Message::Press { button } => {
+                let b = Self::to_physical(button);
+                Some(crate::CanvasMessage::Press { x: b.x, y: b.y })
+            }
+            Message::Release { button } => {
+                let b = Self::to_physical(button);
+                Some(crate::CanvasMessage::Release { x: b.x, y: b.y })
+            }
             Message::TextEndedOrLooped
             | Message::UnknownShortMessage { .. }
             | Message::DeviceInquiry(_)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,8 @@ pub use midi_io::*;
 mod errors;
 pub use errors::*;
 
+mod shared;
+
 pub mod launchpad_s;
 pub use launchpad_s as s;
 
@@ -110,6 +112,7 @@ pub use launch_control as control_xl;
 pub mod prelude {
     pub use crate::canvas::{Canvas, Color, Pad};
     pub use crate::midi_io::{InputDevice, MsgPollingWrapper, OutputDevice};
+    pub use crate::protocols::{LogicalButton, PhysicalButton};
 }
 
 /// Identifier used for e.g. the midi port names etc.

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -1,60 +1,59 @@
 pub(crate) mod double_buffering;
 pub(crate) mod query;
 
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 /// The button type used for Launchpads with 80 buttons
-pub enum Button80 {
+///
+/// This addresses the buttons by their function: the control buttons are
+/// addressed by their index, and the grid buttons are addressed by their
+/// coordinates.
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub enum LogicalButton {
     ControlButton { index: u8 },
     GridButton { x: u8, y: u8 },
 }
 
-impl Button80 {
-    pub const UP: Self = Button80::ControlButton { index: 0 };
-    pub const DOWN: Self = Button80::ControlButton { index: 1 };
-    pub const LEFT: Self = Button80::ControlButton { index: 2 };
-    pub const RIGHT: Self = Button80::ControlButton { index: 3 };
-    pub const SESSION: Self = Button80::ControlButton { index: 4 };
-    pub const USER_1: Self = Button80::ControlButton { index: 5 };
-    pub const USER_2: Self = Button80::ControlButton { index: 6 };
-    pub const MIXER: Self = Button80::ControlButton { index: 7 };
-    pub const VOLUME: Self = Button80::GridButton { x: 8, y: 0 };
-    pub const PAN: Self = Button80::GridButton { x: 8, y: 1 };
-    pub const SEND_A: Self = Button80::GridButton { x: 8, y: 2 };
-    pub const SEND_B: Self = Button80::GridButton { x: 8, y: 3 };
-    pub const STOP: Self = Button80::GridButton { x: 8, y: 4 };
-    pub const MUTE: Self = Button80::GridButton { x: 8, y: 5 };
-    pub const SOLO: Self = Button80::GridButton { x: 8, y: 6 };
-    pub const RECORD_ARM: Self = Button80::GridButton { x: 8, y: 7 };
+impl LogicalButton {
+    pub const UP: Self = Self::ControlButton { index: 0 };
+    pub const DOWN: Self = Self::ControlButton { index: 1 };
+    pub const LEFT: Self = Self::ControlButton { index: 2 };
+    pub const RIGHT: Self = Self::ControlButton { index: 3 };
+    pub const SESSION: Self = Self::ControlButton { index: 4 };
+    pub const USER_1: Self = Self::ControlButton { index: 5 };
+    pub const USER_2: Self = Self::ControlButton { index: 6 };
+    pub const MIXER: Self = Self::ControlButton { index: 7 };
+    pub const VOLUME: Self = Self::GridButton { x: 8, y: 0 };
+    pub const PAN: Self = Self::GridButton { x: 8, y: 1 };
+    pub const SEND_A: Self = Self::GridButton { x: 8, y: 2 };
+    pub const SEND_B: Self = Self::GridButton { x: 8, y: 3 };
+    pub const STOP: Self = Self::GridButton { x: 8, y: 4 };
+    pub const MUTE: Self = Self::GridButton { x: 8, y: 5 };
+    pub const SOLO: Self = Self::GridButton { x: 8, y: 6 };
+    pub const RECORD_ARM: Self = Self::GridButton { x: 8, y: 7 };
 
-    /// Creates a new button out of absolute coordinates, like the ones returned by `abs_x()` and
-    /// `abs_y()`.
-    pub fn from_abs(x: u8, y: u8) -> Button80 {
-        match y {
-            0 => {
-                assert!(x <= 7);
-                Button80::ControlButton { index: x }
-            }
-            1..=8 => {
-                assert!(x <= 8);
-                Button80::GridButton { x, y: y - 1 }
-            }
-            other => panic!("Unexpected y: {}", other),
-        }
+    /// Creates a new GridButton coordinate
+    pub fn grid(x: u8, y: u8) -> Self {
+        Self::GridButton { x, y }
     }
 
-    /// Returns x coordinate assuming coordinate origin in the leftmost control button
-    pub fn abs_x(&self) -> u8 {
-        match *self {
-            Self::ControlButton { index } => index,
-            Self::GridButton { x, .. } => x,
-        }
+    /// Creates a new ControlButton coordinate
+    pub fn control(index: u8) -> Self {
+        Self::ControlButton { index }
     }
+}
 
-    /// Returns y coordinate assuming coordinate origin in the leftmost control button
-    pub fn abs_y(&self) -> u8 {
-        match *self {
-            Self::ControlButton { .. } => 0,
-            Self::GridButton { y, .. } => y + 1,
-        }
+/// A physical button on a LaunchPad, addressed by its location on the pad
+///
+/// Physical buttons include control buttons. Not all physical locations are
+/// necessarily occupied on any specific pad. For example, most 9x9 pads don't
+/// have a button at (8, 0).
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub struct PhysicalButton {
+    pub x: u32,
+    pub y: u32,
+}
+
+impl PhysicalButton {
+    pub fn new(x: u32, y: u32) -> Self {
+        PhysicalButton { x, y }
     }
 }

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,0 +1,60 @@
+//! Routines that are shared between the different LaunchPad implementations
+
+use crate::{
+    protocols::{LogicalButton, PhysicalButton},
+    DeviceSpec,
+};
+
+/// Default implementation of [super::DeviceSpec::to_logical].
+///
+/// This implementation is appropriate for LaunchControl, Mini, MK2, and S.
+///
+/// It uses [DeviceSpec::is_valid] to determine whether or not to return `None`.
+///
+/// # Panics
+///
+/// If the DeviceSpec returns `true` but the coordinates are out of range of a `9x9` grid.
+pub fn default_physical_to_logical<D: DeviceSpec>(button: PhysicalButton) -> Option<LogicalButton> {
+    if !D::is_valid(button.x, button.y) {
+        return None;
+    }
+
+    match button.y {
+        0 => {
+            if button.x < 7 {
+                Some(LogicalButton::ControlButton {
+                    index: button.x as u8,
+                })
+            } else {
+                panic!("Control Button the LaunchPad indicates is valid is too high: {}; do not call default_physical_to_logical", button.x)
+            }
+        }
+        1..=8 => {
+            if button.x <= 8 {
+                Some(LogicalButton::GridButton {
+                    x: button.x as u8,
+                    y: button.y as u8 - 1,
+                })
+            } else {
+                panic!("Grid Button the LaunchPad indicates is valid is too high: ({}, {}); do not call default_physical_to_logical", button.x, button.y)
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Default implementation of [super::DeviceSpec::to_physical].
+///
+/// This implementation is appropriate for LaunchControl, Mini, MK2, and S.
+pub fn default_logical_to_physical(button: LogicalButton) -> PhysicalButton {
+    match button {
+        LogicalButton::ControlButton { index } => PhysicalButton {
+            x: index as u32,
+            y: 0,
+        },
+        LogicalButton::GridButton { x, y } => PhysicalButton {
+            x: x as u32,
+            y: y as u32 + 1,
+        },
+    }
+}


### PR DESCRIPTION
Button80 used to contain the logic for translating between button identifiers and button coordinates. [In the implementation of the Mini Mk3](https://github.com/kangalio/launchy/pull/14#issuecomment-2370302031) it looks like the coordinate translation depends on the type of LaunchPad, so its calculation should involve the LaunchPad code.

In this PR, rename Button80 to LogicalButton (the button identifiers for use with the low-level MIDI interface) and split off PhysicalButton (the X, Y coordinates for use with the Canvas). Translation between them happens via the `DeviceSpec`.

Since up until now the logic could be shared between all LaunchPad implementations, add default implementations for the conversion in `shared/mod.ts` and forward all current implementations there. The implementation of the Mk3 will have its own additional logic.

This is a breaking change to the API.