### PR TITLE
Update Mini MK3 device keyword

### DIFF
--- a/examples/validate-mini-mk3/main.rs
+++ b/examples/validate-mini-mk3/main.rs
@@ -178,11 +178,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut did_see_press = false;
     for msg in input.iter() {
         match msg {
-            Message::Press(button) if button == Button::grid(4, 3) => {
+            Message::Press { button } if button == Button::grid(4, 3) => {
                 println!("Press");
                 did_see_press = true;
             }
-            Message::Release(button) if button == Button::grid(4, 3) => {
+            Message::Release { button } if button == Button::grid(4, 3) => {
                 println!("Release");
                 if did_see_press {
                     break;

--- a/src/launchpad_mini_mk3/input.rs
+++ b/src/launchpad_mini_mk3/input.rs
@@ -63,7 +63,7 @@ impl crate::InputDevice for Input {
     /// - Launchpad Mini MK3 LPMiniMK3 MIDI
     ///
     /// But only the MIDI interface works, so include the "MIDI" string.
-    const MIDI_DEVICE_KEYWORD: &'static str = "Launchpad Mini MK3 LPMiniMK3 MIDI";
+    const MIDI_DEVICE_KEYWORD: &'static str = "Launchpad Mini MK3 LPMiniMK3 MI";
     const MIDI_CONNECTION_NAME: &'static str = "Launchy Mini Mk3 Input";
     type Message = Message;
 

--- a/src/launchpad_mini_mk3/output.rs
+++ b/src/launchpad_mini_mk3/output.rs
@@ -296,7 +296,7 @@ impl crate::OutputDevice for Output {
     /// - "Launchpad Mini MK3 LPMiniMK3 MIDI"
     ///
     /// But only the MIDI interface works for what we want to do, so include the "MIDI" string.
-    const MIDI_DEVICE_KEYWORD: &'static str = "Launchpad Mini MK3 LPMiniMK3 MIDI";
+    const MIDI_DEVICE_KEYWORD: &'static str = "Launchpad Mini MK3 LPMiniMK3 MI";
 
     fn from_connection(connection: MidiOutputConnection) -> Result<Self, crate::MidiError> {
         let mut self_ = Self { connection };


### PR DESCRIPTION
This PR changes the midi device keyword for the Mini MK3 from `Launchpad Mini MK3 LPMiniMK3 MIDI` to `Launchpad Mini MK3 LPMiniMK3 MI`.

For some reason the `DI` part is cut from the MIDI port name on my system. The device keyword without the `DI` doesn't conflict with anything so I don't think this change does any harm.