### PR TITLE
Set relaxed keyword detection for mini MK3

### DIFF
--- a/src/launchpad_mini_mk3/input.rs
+++ b/src/launchpad_mini_mk3/input.rs
@@ -63,7 +63,7 @@ impl crate::InputDevice for Input {
     /// - Launchpad Mini MK3 LPMiniMK3 MIDI
     ///
     /// But only the MIDI interface works, so include the "MIDI" string.
-    const MIDI_DEVICE_KEYWORD: &'static str = "Launchpad Mini MK3 LPMiniMK3 MIDI";
+    const MIDI_DEVICE_KEYWORD: &'static str = "Launchpad Mini MK3 LPMiniMK3 MI";
     const MIDI_CONNECTION_NAME: &'static str = "Launchy Mini Mk3 Input";
     type Message = Message;
 

--- a/src/launchpad_mini_mk3/input.rs
+++ b/src/launchpad_mini_mk3/input.rs
@@ -56,13 +56,14 @@ fn decode_control_button(btn: u8) -> Button {
 
 impl crate::InputDevice for Input {
     /// Device name.
+    /// 
+    /// Here's OS MIDI device names seen in the wild:
+    /// - Launchpad Mini MK3 LPMiniMK3 DAW (MacOS)
+    /// - Launchpad Mini MK3 LPMiniMK3 MIDI (MacOS)
+    /// - Launchpad Mini MK3:Launchpad Mini MK3 LPMiniMK3 DA 32:0 (Linux)
+    /// - Launchpad Mini MK3:Launchpad Mini MK3 LPMiniMK3 MI 32:1 (Linux)
     ///
-    /// On MacOS, the Mini MK3 advertises
-    ///
-    /// - Launchpad Mini MK3 LPMiniMK3 DAW
-    /// - Launchpad Mini MK3 LPMiniMK3 MIDI
-    ///
-    /// But only the MIDI interface works, so include the "MIDI" string.
+    /// On some platforms, the string is truncated, and the device with "DAW" in its name does not work.
     const MIDI_DEVICE_KEYWORD: &'static str = "Launchpad Mini MK3 LPMiniMK3 MI";
     const MIDI_CONNECTION_NAME: &'static str = "Launchy Mini Mk3 Input";
     type Message = Message;

--- a/src/launchpad_mini_mk3/input.rs
+++ b/src/launchpad_mini_mk3/input.rs
@@ -56,7 +56,7 @@ fn decode_control_button(btn: u8) -> Button {
 
 impl crate::InputDevice for Input {
     /// Device name.
-    /// 
+    ///
     /// Here's OS MIDI device names seen in the wild:
     /// - Launchpad Mini MK3 LPMiniMK3 DAW (MacOS)
     /// - Launchpad Mini MK3 LPMiniMK3 MIDI (MacOS)

--- a/src/launchpad_mini_mk3/output.rs
+++ b/src/launchpad_mini_mk3/output.rs
@@ -287,13 +287,14 @@ impl crate::OutputDevice for Output {
     const MIDI_CONNECTION_NAME: &'static str = "Launchy Mini Mk3 output";
 
     /// Device name.
+    /// 
+    /// Here's OS MIDI device names seen in the wild:
+    /// - Launchpad Mini MK3 LPMiniMK3 DAW (MacOS)
+    /// - Launchpad Mini MK3 LPMiniMK3 MIDI (MacOS)
+    /// - Launchpad Mini MK3:Launchpad Mini MK3 LPMiniMK3 DA 32:0 (Linux)
+    /// - Launchpad Mini MK3:Launchpad Mini MK3 LPMiniMK3 MI 32:1 (Linux)
     ///
-    /// On MacOS, the Mini MK3 advertises:
-    ///
-    /// - "Launchpad Mini MK3 LPMiniMK3 DAW"
-    /// - "Launchpad Mini MK3 LPMiniMK3 MIDI"
-    ///
-    /// But only the MIDI interface works for what we want to do, so include the "MIDI" string.
+    /// On some platforms, the string is truncated, and the device with "DAW" in its name does not work.
     const MIDI_DEVICE_KEYWORD: &'static str = "Launchpad Mini MK3 LPMiniMK3 MI";
 
     fn from_connection(connection: MidiOutputConnection) -> Result<Self, crate::MidiError> {

--- a/src/launchpad_mini_mk3/output.rs
+++ b/src/launchpad_mini_mk3/output.rs
@@ -287,7 +287,7 @@ impl crate::OutputDevice for Output {
     const MIDI_CONNECTION_NAME: &'static str = "Launchy Mini Mk3 output";
 
     /// Device name.
-    /// 
+    ///
     /// Here's OS MIDI device names seen in the wild:
     /// - Launchpad Mini MK3 LPMiniMK3 DAW (MacOS)
     /// - Launchpad Mini MK3 LPMiniMK3 MIDI (MacOS)

--- a/src/launchpad_mini_mk3/output.rs
+++ b/src/launchpad_mini_mk3/output.rs
@@ -294,7 +294,7 @@ impl crate::OutputDevice for Output {
     /// - "Launchpad Mini MK3 LPMiniMK3 MIDI"
     ///
     /// But only the MIDI interface works for what we want to do, so include the "MIDI" string.
-    const MIDI_DEVICE_KEYWORD: &'static str = "Launchpad Mini MK3 LPMiniMK3 MIDI";
+    const MIDI_DEVICE_KEYWORD: &'static str = "Launchpad Mini MK3 LPMiniMK3 MI";
 
     fn from_connection(connection: MidiOutputConnection) -> Result<Self, crate::MidiError> {
         let mut self_ = Self { connection };


### PR DESCRIPTION
guess_polling() is not working on linux otherwise. Fix #18 